### PR TITLE
Добавление возможности подсвечивать различия в истории изменения тем. 

### DIFF
--- a/src/main/java/ru/org/linux/topic/EditInfoController.java
+++ b/src/main/java/ru/org/linux/topic/EditInfoController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
 import java.util.List;
 
 @Controller
@@ -47,6 +48,11 @@ public class EditInfoController {
     List<PreparedEditInfo> editInfos = prepareService.prepareEditInfo(message, request.isSecure());
 
     ModelAndView mv = new ModelAndView("history");
+    
+    List<String> javaScriptsForLayout = new ArrayList<String>();
+    javaScriptsForLayout.add("diff_match_patch.js");
+    javaScriptsForLayout.add("lor_view_diff_history.js");
+    mv.addObject("javascriptsForLayout", javaScriptsForLayout);
 
     mv.getModel().put("message", message);
     mv.getModel().put("editInfos", editInfos);

--- a/src/main/webapp/WEB-INF/jsp/header.jsp
+++ b/src/main/webapp/WEB-INF/jsp/header.jsp
@@ -21,6 +21,13 @@
 <link rel="top" title="Linux.org.ru" href="/">
 <script src="/js/lor.js" type="text/javascript">;</script>
 
+<c:if test="${javascriptsForLayout != null}">
+  <c:forEach items="${javascriptsForLayout}" var="javascriptForLayout">
+    <c:url value="/js/${javascriptForLayout}" var="jsURL"/>
+    <script src="${jsURL}" type="text/javascript"></script>
+  </c:forEach>
+</c:if>
+
 <c:if test="${pageContext.request.secure}">
   <base href="${fn:escapeXml(template.secureMainUrl)}">
 </c:if>

--- a/src/main/webapp/WEB-INF/jsp/history.jsp
+++ b/src/main/webapp/WEB-INF/jsp/history.jsp
@@ -22,7 +22,7 @@
 <title>История изменений</title>
 <jsp:include page="/WEB-INF/jsp/header.jsp"/>
 <h1>История изменений</h1>
-
+<div id="historyButtonBar"></div>
 <div class="messages">
   <c:forEach items="${editInfos}" var="editInfo">
     <p>

--- a/src/main/webapp/common.css
+++ b/src/main/webapp/common.css
@@ -358,3 +358,11 @@ table.poll-result img {
 div.quote p cite {
     text-decoration: underline;
 }
+
+.difference-insert {
+  background-color: green;
+}
+
+.difference-delete {
+  background-color: red;
+}

--- a/src/main/webapp/js/diff_match_patch.js
+++ b/src/main/webapp/js/diff_match_patch.js
@@ -1224,16 +1224,17 @@ diff_match_patch.prototype.diff_prettyHtml = function(diffs) {
     var op = diffs[x][0];    // Operation (insert, delete, equal)
     var data = diffs[x][1];  // Text of change.
     var text = data.replace(pattern_amp, '&amp;').replace(pattern_lt, '&lt;')
-        .replace(pattern_gt, '&gt;').replace(pattern_para, '&para;<br>');
+        .replace(pattern_gt, '&gt;');
+    // text = text.replace(pattern_para, '&para;<br>');
     switch (op) {
       case DIFF_INSERT:
-        html[x] = '<ins style="background:#e6ffe6;">' + text + '</ins>';
+        html[x] = '<span class="difference-insert">' + text + '</span>';
         break;
       case DIFF_DELETE:
-        html[x] = '<del style="background:#ffe6e6;">' + text + '</del>';
+        html[x] = '<span class="difference-delete">' + text + '</span>';
         break;
       case DIFF_EQUAL:
-        html[x] = '<span>' + text + '</span>';
+        html[x] = text;
         break;
     }
   }

--- a/src/main/webapp/js/lor_view_diff_history.js
+++ b/src/main/webapp/js/lor_view_diff_history.js
@@ -1,0 +1,98 @@
+var LorViewDiffHistory = function() {
+  return {
+    htmlHash: {},
+    currentHash: 44032,
+    dmp: new diff_match_patch(),
+
+    pushHash: function (tag) {
+       if (typeof(this.htmlHash[tag]) == 'undefined') {
+        this.htmlHash[tag] = eval('"\\u'+this.currentHash.toString(16)+'"');
+        this.currentHash++;
+      }
+      return this.htmlHash[tag];
+    },
+
+    clearHash: function () {
+      this.htmlHash = {};
+      this.currentHash = 44032;
+    },
+
+    html2plain: function (html) {
+      html = html.replace(/<(S*?)[^>]*>.*?|<.*?\/>/g, function(tag){
+          return document.lorViewDiffHistory.pushHash(tag.toUpperCase());
+      });
+
+      return html;
+    },
+
+    plain2html: function (plain) {
+      for(var tag in this.htmlHash){
+        plain = plain.replace(RegExp(this.htmlHash[tag], 'g'), tag);
+      }
+      return plain;
+    },
+
+    highlightContentDiff: function (object1, object2) {
+      var content1 = this.html2plain ($(object1).html());
+      var content2 = this.html2plain ($(object2).html());
+
+      var diffs = this.dmp.diff_main(content1, content2);
+      var html = this.dmp.diff_prettyHtml(diffs);
+
+      return this.plain2html(html);
+    }
+  };
+}
+
+function diffHighlightOn(button) {
+  document.prev_object = null;
+  $("div.messages div.msg div.msg_body").each(
+    function(ind, obj){
+      $(obj).attr("oldHtml", $(obj).html());
+      if (document.prev_object == null) {
+        document.prev_object = obj;
+        return;
+      }
+      var html = document.lorViewDiffHistory.highlightContentDiff(obj, document.prev_object);
+      $(document.prev_object).html(html);
+      document.prev_object = obj;
+    }
+  );
+}
+
+function diffHighlightOff(button) {
+  document.prev_object = null;
+  $("div.messages div.msg div.msg_body").each(
+    function(ind, obj){
+      $(obj).html($(obj).attr("oldHtml"));
+    }
+  );
+}
+
+function toggleDiffHighlight(obj) {
+  var button = obj.currentTarget;
+  var attr = $(button).attr("highlighted");
+  if (attr == "on") {
+    $(button)
+      .val("Подсветить различия")
+      .attr("highlighted", "off");
+    diffHighlightOff(button);
+  } else {
+    $(button)
+      .val("Убрать подсветку")
+      .attr("highlighted", "on");
+    diffHighlightOn(button);
+  }
+}
+
+$(document).ready(function() {
+  document.lorViewDiffHistory = new LorViewDiffHistory();
+  var button = $('<input type="button">')
+    .val("Подсветить различия")
+    .attr("highlighted", "off")
+    .addClass("toggleDiffHighlight")
+    .appendTo($("#historyButtonBar"))
+    .click(function(obj){
+      toggleDiffHighlight(obj)
+    });
+});


### PR DESCRIPTION
Мне не хватало такой фишки. Заходя на страницу истории изменений, трудно понять, что же именно изменилось между правками, особенно если сообщение большое. Сейчас будет видно.

С цветами я не заморачивался: background: green для добавлений и background: red для удалений. Если нужны подстройки цветов под различные темы, то нужно будет дополнительно обговорить цвета и повносить их в соответствующие CSS (в этом бранче или напрямую в master).

Подсветка различий полностью работает на JavaScript. Скрипт взят отсюда: http://google-diff-match-patch.googlecode.com/svn/trunk/javascript/diff_match_patch.js

Иногда подсвечивает лишнее. Например, в истории изменений у первого изменения есть заголовок (H2), у последующих изменений заголовка может не быть. В этом случае заголовок подсвечивается как удалённая строка. Также почему-то много подсвечивается как-бы пустых строк, но вероятно это, опять же, недостаток форматирования элементов истории изменений топика. Думаю, нужно будет пересмотреть структуру элементов истории, чтобы сравнение происходило только лишь по "телу" сообщения, безо всяких заголовков, тегов и т.д. Но, наверное, этот пересмотр за рамками данной фичи и больше относится к html-рефакторингу.
