### PR TITLE
fix, copy-paste скрытых элементов цитат в firefox 3.5 и старше

### DIFF
--- a/src/main/webapp/js/lor.js
+++ b/src/main/webapp/js/lor.js
@@ -125,6 +125,9 @@ $(document).ready(function() {
       title : "Введите заголовок"
     }
   });
+
+  // remove hidden quote elements
+  $(".none").remove()
 });
 
 hljs.initHighlightingOnLoad();


### PR DESCRIPTION
гениальное решение проблемы copy-paste скрытого офрмеления цитат, основывается на том, что в текстовых браузерах неработает js

см. https://www.linux.org.ru/forum/lor-source/7495016
