### PR TITLE
удалил ненужную ссылку в заголовке бокслета опросов

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/boxlets/poll.jsp
+++ b/src/main/webapp/WEB-INF/jsp/boxlets/poll.jsp
@@ -19,8 +19,7 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib tagdir="/WEB-INF/tags" prefix="lor" %>
 
-  <c:url value="/polls/" var="main_url"/>
-  <h2><a href="${main_url}">Опрос</a></h2>
+  <h2>Опрос</h2>
 
   <div class="boxlet_content">
     <h3>${message.title}</h3>


### PR DESCRIPTION
она плохо выглядит в теме while2, да и не нужна, т.к. есть ссылки в теле бокслета.
