### PR TITLE
добавлять в Og ошметки code, а значит проверять по ним пустоту комментария

### DIFF
--- a/src/main/java/ru/org/linux/util/bbcode/nodes/TextCodeNode.java
+++ b/src/main/java/ru/org/linux/util/bbcode/nodes/TextCodeNode.java
@@ -53,6 +53,11 @@ public class TextCodeNode extends TextNode {
   }
 
   @Override
+  public String renderOg() {
+    return StringUtil.escapeForceHtml(text);
+  }
+
+  @Override
   public String renderXHtml() {
     return StringUtil.escapeForceHtml(text);
   }

--- a/src/main/java/ru/org/linux/util/bbcode/tags/CodeTag.java
+++ b/src/main/java/ru/org/linux/util/bbcode/tags/CodeTag.java
@@ -93,11 +93,6 @@ public class CodeTag extends Tag {
   }
 
   @Override
-  public String renderNodeOg(Node node) {
-    return "";
-  }
-
-  @Override
   public String renderNodeXhtml(Node node) {
     if (node.lengthChildren() == 0) {
       return "";

--- a/src/test/java/ru/org/linux/util/HTMLFormatterTest.java
+++ b/src/test/java/ru/org/linux/util/HTMLFormatterTest.java
@@ -596,7 +596,7 @@ public class HTMLFormatterTest {
         lorCodeService.parseForOgDescription("due\n[quote][quote]one[br][/quote]teo[br][quote]neo[br][/quote][/quote]wuf?\nok")
     );
     assertEquals(
-        "",
+        "&amp;#9618;",
         lorCodeService.parseForOgDescription("[code]&#9618;[/code]")
     );
     String txt = "many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]many many [b]texxt [/b]";
@@ -662,6 +662,7 @@ public class HTMLFormatterTest {
     assertTrue(lorCodeService.isEmptyTextComment("[b] [br][/b][u] "));
     assertTrue(lorCodeService.isEmptyTextComment("[list][*][br][br][*][u][/u][/list]"));
     assertTrue(lorCodeService.isEmptyTextComment("[url]   [/url][list][*][br][br][*][u][/u][/list][/url]"));
+    assertFalse(lorCodeService.isEmptyTextComment("[code]text[/code]"));
   }
 
   @Test


### PR DESCRIPTION
Только вот я не помню, почему мы из Og исключили текст code в 23b0d4cab8f240d48a25a13b357e2e4d21343d92
