### PR TITLE
JSR305 fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,13 @@
             <version>12.0</version>
         </dependency>
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>1.3.9</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
             <version>1.3</version>


### PR DESCRIPTION
Возможно, у кого-то будет, как и у меня, мешашина в ~/.m2/repository, которую чистить не хочется (несколько гигов всё таки) и из-за которой не находится класс  javax.annotation.Nonnull. Этот фикс решает проблему ненахождения библиотеки com.google.code.findbugs.jsr305.
