### PR TITLE
Fix "back" link in the upload-size error page

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/errors/upload-size.jsp
+++ b/src/main/webapp/WEB-INF/jsp/errors/upload-size.jsp
@@ -27,7 +27,7 @@
     <div id="warning-text">
         <h1>Слишком крупное изображение</h1>
         <p>Размер изображения превышает лимит в ${exception.maxUploadSize} Байт</p>
-        <p>Вернитесь <a href="java script:history.back()">назад</a></p>
+        <p>Вернитесь <a href="javascript:history.back()">назад</a></p>
     </div>
 </div>
 <div id="warning-footer"></div>


### PR DESCRIPTION
Опечатка в URL ссылки "назад" при слишком большом upload'е:
http://www.linux.org.ru/forum/lor-source/10124025?lastmod=1391208043033#comment-10124040
