### PR TITLE
remove unnecessary collection conversion

### DIFF
--- a/src/main/scala/ru/org/linux/topic/TopicTagService.scala
+++ b/src/main/scala/ru/org/linux/topic/TopicTagService.scala
@@ -144,7 +144,7 @@ class TopicTagService @Autowired() (
     builder.build()
   }
 
-  def tagRefs(topics:Seq[Int]) = topicTagDao.getTags(topics).groupBy(_._1).toMap.mapValues(_.map(_._2))
+  def tagRefs(topics:Seq[Int]) = topicTagDao.getTags(topics).groupBy(_._1).mapValues(_.map(_._2))
 
   /**
    * Получить все теги сообщения по идентификационному номеру сообщения.


### PR DESCRIPTION
На сколько я понимаю, промежуточное преобразование `toMap` не нужно. `groupBy` сам по себе возвращает `map`:
```scala
groupBy[K](f : scala.Function1[A, K]) : scala.collection.immutable.Map[K, Repr]
```