### PR TITLE
Opera Mini спасена

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <scala.suffix>2.11</scala.suffix>
     <activemq.version>5.11.1</activemq.version>
     <slf4j.version>1.7.5</slf4j.version>
-    <jquery.validation.version>1.13.1</jquery.validation.version>
+    <jquery.validation.version>1.14.0</jquery.validation.version>
     <jquery.form.version>3.51</jquery.form.version>
     <jetty.version>9.3.0.v20150612</jetty.version>
   </properties>


### PR DESCRIPTION
В свежем jquery-validation, который вышел, на минуточку, ещё четыре месяца назад, уже впилили обход эпичнейшего бага в движке транскодеров Opera Mini. Работоспособность проверял, пруф: http://pic4a.ru/510/uJ.png. Вот только для пересборки combined-бандла пришлось ещё в конфиге обёртки для yuicompressor параметр &lt;force>true&lt;/force> указать. Это дело можно менее костыльно разрулить, если не менялись никакие родные скрипты ЛОРа, включаемые в бандл?