### PR TITLE
Remove link to lorwiki

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/server.jsp
+++ b/src/main/webapp/WEB-INF/jsp/server.jsp
@@ -154,7 +154,6 @@
 <li><a href="http://www.lorquotes.ru/">LorQuotes</a>&nbsp;&#8212; избранные цитаты</li>
 <li><a href="http://www.lastfm.ru/group/Linux-org-ru">Группа linux.org.ru на&nbsp;last.fm</a></li>
 <li><a href="http://community.livejournal.com/l_o_r/">Филиал l.o.r. в&nbsp;ЖЖ</a></li>
-<li><a href="http://lorwiki.ru/">Продолжение развития LOR Wiki, бывшей части проекта</a></li>
 </ul>
 
 <jsp:include page="/WEB-INF/jsp/footer.jsp"/>


### PR DESCRIPTION
Убрать ссылку на lorwiki.ru

Причины: 

1. Нарушение авторских прав (https://www.linux.org.ru/forum/linux-org-ru/11975352).

2. Содержимое https://lorwiki.ru/wiki/Модерация.