### PR TITLE
made inline breakable on tablets and phones

### DIFF
--- a/src/main/webapp/sass/_responsive.scss
+++ b/src/main/webapp/sass/_responsive.scss
@@ -91,6 +91,10 @@
         margin: 0;
     }
 
+    code {
+        white-space: pre-wrap;
+    }
+
 }
 
 /* phone */


### PR DESCRIPTION
Пользователи жаловались, что длинные inline не переносятся на телефонах: https://www.linux.org.ru/forum/linux-org-ru/12837247?cid=12840127

На десктопах не стал изменять поведение, чтобы inline не переносился, когда в этом нет необходимости.