### PR TITLE
CVE-2016-3720 Bump jackson stack version to avoid XXE vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     <jquery.form.version>3.51</jquery.form.version>
     <jetty.version>9.3.12.v20160915</jetty.version>
     <akka.version>2.4.11</akka.version>
+    <jackson.version>2.7.4</jackson.version>
   </properties>
 
   <dependencies>
@@ -237,6 +238,24 @@
         <groupId>org.elasticsearch</groupId>
         <artifactId>elasticsearch</artifactId>
         <version>${es.version}</version>
+        <exclusions>
+            <exclusion>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-smile</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-cbor</artifactId>
+            </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
             <groupId>org.slf4j</groupId>
@@ -299,15 +318,34 @@
         </dependency>
 
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>2.6.2</version>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+          <version>${jackson.version}</version>
       </dependency>
-
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>2.6.2</version>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
+          <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+          <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>com.fasterxml.jackson.dataformat</groupId>
+          <artifactId>jackson-dataformat-smile</artifactId>
+          <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>com.fasterxml.jackson.dataformat</groupId>
+          <artifactId>jackson-dataformat-yaml</artifactId>
+          <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>com.fasterxml.jackson.dataformat</groupId>
+          <artifactId>jackson-dataformat-cbor</artifactId>
+          <version>${jackson.version}</version>
       </dependency>
 
     <dependency>


### PR DESCRIPTION
Подняла версию Jackson, чтобы пофиксить уязвимость с использованием внешних DTD -- в версии 2.7.4 внешние схемы будут проигнорированы.
Версия Jackson проверена по всему дереву зависимостей, чтобы избежать конфликта версий.
Интеграционные тесты проходят успешно. 