### PR TITLE
Удаление ветки комментариев без удаления ответов

### DIFF
--- a/src/main/java/ru/org/linux/comment/CommentPrepareService.java
+++ b/src/main/java/ru/org/linux/comment/CommentPrepareService.java
@@ -93,7 +93,11 @@ public class CommentPrepareService {
       if (comment.getReplyTo() != 0) {
         CommentNode replyNode = comments.getNode(comment.getReplyTo());
 
-        if (replyNode!=null) {
+        boolean replyDeleted = replyNode == null;
+        if (replyDeleted) {
+          // ответ на удаленный комментарий
+          replyInfo = new ReplyInfo(comment.getReplyTo(), replyDeleted);
+        } else {
           Comment reply = replyNode.getComment();
 
           boolean samePage = false;
@@ -110,7 +114,8 @@ public class CommentPrepareService {
                   replyAuthor,
                   Strings.emptyToNull(reply.getTitle().trim()),
                   reply.getPostdate(),
-                  samePage
+                  samePage,
+                  replyDeleted
           );
         }
       }

--- a/src/main/java/ru/org/linux/comment/ReplyInfo.java
+++ b/src/main/java/ru/org/linux/comment/ReplyInfo.java
@@ -30,19 +30,33 @@ public class ReplyInfo {
   private final String title;
   private final Date postdate;
   private final boolean samePage;
+  private final boolean deleted;
+
+  public ReplyInfo(int id, boolean deleted) {
+    this.id = id;
+    this.deleted = deleted;
+    // Для удаленных сообщений не имеет значения,
+    // так как эта информация не должна отображаться.
+    this.author = null;
+    this.title = null;
+    this.postdate = new Date(0);
+    this.samePage = false;
+  }
 
   public ReplyInfo(
           int id,
           @Nonnull String author,
           @Nullable String title,
           @Nonnull Date postdate,
-          boolean samePage
+          boolean samePage,
+          boolean deleted
   ) {
     this.id = id;
     this.author = author;
     this.title = title;
     this.postdate = postdate;
     this.samePage = samePage;
+    this.deleted = deleted;
   }
 
   public int getId() {
@@ -63,5 +77,9 @@ public class ReplyInfo {
 
   public boolean isSamePage() {
     return samePage;
+  }
+
+  public boolean isDeleted() {
+    return deleted;
   }
 }

--- a/src/main/scala/ru/org/linux/comment/DeleteCommentController.scala
+++ b/src/main/scala/ru/org/linux/comment/DeleteCommentController.scala
@@ -72,6 +72,7 @@ class DeleteCommentController(searchQueueSender: SearchQueueSender, commentServi
   @RequestMapping(value = Array("/delete_comment.jsp"), method = Array(RequestMethod.POST))
   def deleteComments(@RequestParam("msgid") msgid: Int, @RequestParam("reason") reason: String,
                      @RequestParam(value = "bonus", defaultValue = "0") bonus: Int,
+                     @RequestParam(value = "delete_replys", defaultValue = "false") deleteReplys: Boolean,
                      request: HttpServletRequest): ModelAndView = {
     if (bonus < 0 || bonus > 20) {
       throw new BadParameterException("неправильный размер штрафа")
@@ -104,9 +105,17 @@ class DeleteCommentController(searchQueueSender: SearchQueueSender, commentServi
         0
       }
 
-      commentDeleteService.deleteWithReplys(topic, comment, reason, user, effectiveBonus).asScala
+      if (deleteReplys) {
+        commentDeleteService.deleteWithReplys(topic, comment, reason, user, effectiveBonus).asScala
+      } else {
+        if (commentDeleteService.deleteComment(msgid, reason, user, effectiveBonus, false)) {
+          Seq(msgid)
+        } else {
+          Seq.empty
+        }
+      }
     } else {
-      if (commentDeleteService.deleteComment(msgid, reason, user)) {
+      if (commentDeleteService.deleteComment(msgid, reason, user, 0, true)) {
         Seq(msgid)
       } else {
         Seq.empty

--- a/src/main/webapp/WEB-INF/jsp/delete_comment.jsp
+++ b/src/main/webapp/WEB-INF/jsp/delete_comment.jsp
@@ -91,6 +91,15 @@
   </div>
   </c:if>
 
+  <c:if test="${template.moderatorSession}">
+  <div class="control-group">
+    <label class="control-label">Удалять ответы</label>
+    <div class="controls">
+      <input type="checkbox" name="delete_replys" checked>
+    </div>
+  </div>
+  </c:if>
+
  <input type=hidden name=msgid value="${msgid}">
   <div class="control-group">
     <div class="controls">

--- a/src/main/webapp/sass/_form.scss
+++ b/src/main/webapp/sass/_form.scss
@@ -22,6 +22,10 @@ input[type="search"] {
     -webkit-appearance: textfield;
 }
 
+input[type="checkbox"] {
+    width: auto !important;
+}
+
 .input-lg {
   padding: 6px 3px;
   vertical-align: middle;

--- a/src/main/webapp/template/comment.jade
+++ b/src/main/webapp/template/comment.jade
@@ -26,19 +26,22 @@ mixin comment(comment, enableSchema, topic, showMenu)
                     br
     
             if comment.reply!=null
-                if comment.reply.samePage
-                    samePage = "samePage"
+                if comment.reply.deleted
+                    | Ответ на: удаленный комментарий
                 else
-                    samePage = false
-    
-                | Ответ на:#{' '}
-                a(href='#{topic.link}?cid=#{comment.reply.id}', data-samepage=samePage)
-                    if comment.reply.title != null
-                        | !{comment.reply.title}
+                    if comment.reply.samePage
+                        samePage = "samePage"
                     else
-                        | комментарий
-                |  от #{comment.reply.author}#{' '}
-                mixin time(comment.reply.postdate, false)
+                        samePage = false
+
+                    | Ответ на:#{' '}
+                    a(href='#{topic.link}?cid=#{comment.reply.id}', data-samepage=samePage)
+                        if comment.reply.title != null
+                            | !{comment.reply.title}
+                        else
+                            | комментарий
+                    |  от #{comment.reply.author}#{' '}
+                    mixin time(comment.reply.postdate, false)
 
         div.msg-container
             if comment.userpic


### PR DESCRIPTION
Основано на:
- https://www.linux.org.ru/forum/lor-source/4697041;
- https://www.linux.org.ru/forum/linux-org-ru/13741076;

Что изменяется:
- добавляет галочку «удалять с ответами»;
- при снятии галочки «удалять с ответами» удаляется только первое сообщение ветки;
- для ответов на удаленные сообщения отображается «Ответ на: удаленный комментарий».