### PR TITLE
Полностью отключить font boosting в Chrome на Android

### DIFF
--- a/src/main/webapp/sass/_common.scss
+++ b/src/main/webapp/sass/_common.scss
@@ -49,6 +49,10 @@ html {
   }
 }
 
+body * {
+    max-height: 9999999em; /* disable font boosting in mobile browsers */
+}
+
 body {
    max-width: 89em;
    margin: auto;


### PR DESCRIPTION
Text-size-adjust и viewport не всегда достаточны для того, чтобы Chrome не применял алгоритм font boosting по своему усмотрению. Если пользователь в настройках браузера выставил размер шрифта по умолчанию больше 100% - Chrome будет не масштабировать все шрифты под этот коэффициент, а применять алгоритм font boosting с этим коэффициентом - даже к страницам, у которых есть text-size-adjust и определен viewport.

В результате разные элементы страницы могут получить разный зум шрифта. [Пример](https://user-images.githubusercontent.com/334908/45468684-96222980-b72e-11e8-9615-aaf6928a688b.png): сравните размер шрифта в заголовке темы про APT с остальными темами.

Больше информации (см. раздел Accessibility Text Scaling):
<https://docs.google.com/document/d/1PPcEwAhXJJ1TQShor29KWB17KJJq7UJOM34oHwYP3Zg>

Возможно, проблему можно решить, выставив text-size-adjust:none, но это может привести к [проблемам с зумом](https://www.456bereastreet.com/archive/201011/beware_of_-webkit-text-size-adjustnone/) в некоторых десктопных браузерах. Предложенная мной max-height, на первый взгляд, не имеет деструктивных последствий - но тестировал я далеко не все возможные страницы.