### PR TITLE
Disable displaying titles of deleted topics in links

### DIFF
--- a/src/main/java/ru/org/linux/util/formatter/ToHtmlFormatter.java
+++ b/src/main/java/ru/org/linux/util/formatter/ToHtmlFormatter.java
@@ -239,14 +239,21 @@ public class ToHtmlFormatter {
       String urlTitle = linkText!=null?simpleFormat(linkText):StringUtil.escapeHtml(message.getTitle());
 
       String newUrlHref = url.formatJump(messageDao, siteConfig.getSecureURI());
+      String fixedUrlBody = url.formatUrlBody(maxLength);
 
       if (deleted) {
         out.append("<s>");
       }
       
-      out.append("<a href=\"").append(newUrlHref).append("\" title=\"").append(urlTitle).append("\">")
-              .append(urlTitle)
-              .append("</a>");
+      out.append("<a href=\"").append(newUrlHref).append("\" title=\"").append(urlTitle).append("\">");
+
+      if (deleted) {
+        out.append(StringUtil.escapeHtml(fixedUrlBody));
+      } else {
+        out.append(urlTitle);
+      }
+
+      out.append("</a>");
 
       if (deleted) {
         out.append("</s>");


### PR DESCRIPTION
Отображение заголовков удалённых сообщений в ссылках представляет собою вопиющую уязвимость, предоставляющую возможность подставлять других пользователей форума. Вижу как минимум два сценария эксплуатации оной:

1) Пользователь Аня создаёт топик с не нарушающим правила заголовком. Пользователь Боря создаёт пост со ссылкой на этот топик. Затем Аня меняет название топика на нарушающее правила, топик пользователя Аня удаляют модераторы, но текст поста пользователя Боря по-прежнему продолжает нарушать правила.

2) Более простой, продемонстрированный мною: пользователь Аня создаёт топик с нарушающим правила заголовком, пользователь Боря доносит на него в спецтопик; топик пользователя Аня удаляется, но текст заголовка остаётся висеть в спецтопике, если модераторы не удалят также пост пользователя Боря.

Нарушения могут быть разными, вплоть до публикации запрещённых в РФ материалов наподобие описания способов суицида; таким образом, даже если модераторы удалят топики нарушителя, размещённая в их заголовке информация может остаться в постах других пользователей, и придётся разрабатывать инструменты для поиска и удаления постов, ссылающихся на удалённый топик.

Я предлагаю более простое решение — вернуть для удалённых, как было. А лучше и title убрать, хотя бы для незарегистрированных.