### PR TITLE
Strip unicode emojis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -437,6 +437,12 @@
       <artifactId>flexmark-all</artifactId>
       <version>0.35.6</version>
     </dependency>
+
+    <dependency>
+      <groupId>com.ibm.icu</groupId>
+      <artifactId>icu4j</artifactId>
+      <version>63.1</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/ru/org/linux/util/StringUtil.java
+++ b/src/main/java/ru/org/linux/util/StringUtil.java
@@ -15,6 +15,8 @@
 
 package ru.org.linux.util;
 
+import com.ibm.icu.lang.UProperty;
+import com.ibm.icu.lang.UCharacter;
 import ru.org.linux.util.formatter.RuTypoChanger;
 import ru.org.linux.util.formatter.ToHtmlFormatter;
 
@@ -132,6 +134,23 @@ public final class StringUtil {
           res.append(str.charAt(i));
       }
 
+    }
+
+    return removeAllEmojis(res.toString());
+  }
+
+  /**
+   * Удаление unicode смайликов из строки
+   * @param str сырая строка
+   * @return строка без смайликов
+   */
+  private static String removeAllEmojis(String str) {
+    StringBuilder res = new StringBuilder();
+
+    for(int codePoint : str.codePoints().toArray()) {
+      if (!UCharacter.hasBinaryProperty(codePoint, UProperty.EMOJI)) {
+        res.appendCodePoint(codePoint);
+      }
     }
 
     return res.toString();


### PR DESCRIPTION
Смайлики затрудняют чтение постов, делая форум «пестрым» при их отображении, либо представляют собой непонятные квадраты в том случае, если их отображение не поддерживается.

Данный патч устраняет данную проблему, исключая смайлики во время записи сообщений в БД

Протестировано на всех типах сообщений и тем.