### PR TITLE
Add automatic spoilers for code tags

### DIFF
--- a/src/main/webapp/js/lor.js
+++ b/src/main/webapp/js/lor.js
@@ -421,6 +421,24 @@ $(document).ready(function() {
     });
   }
 
+  function spoilerShow() {
+    var $this = $(this);
+    $this.parent().removeClass('spoiled');
+    $this.remove();
+    return false;
+  }
+
+  function initCodeSpoilers() {
+    $('.code').each(function() {
+      var $this = $(this);
+      if ($this.height() > 512) {
+        $this
+          .append($('<a href="#" class="spoiler-open">Развернуть</a>').on('click', spoilerShow))
+          .addClass('spoiled');
+      }
+    });
+  }
+
   initCtrlEnter();
   initUpdateEventsCount();
 
@@ -429,4 +447,6 @@ $(document).ready(function() {
   
   replace_state()
   $(window).bind('hashchange', replace_state);
+
+  initCodeSpoilers();
 });

--- a/src/main/webapp/sass/_common.scss
+++ b/src/main/webapp/sass/_common.scss
@@ -787,3 +787,5 @@ figure.medium-image {
 @import "form";
 @import "mainpage";
 @import "topic_page";
+
+@import "spoilers"

--- a/src/main/webapp/sass/_spoilers.scss
+++ b/src/main/webapp/sass/_spoilers.scss
@@ -1,0 +1,33 @@
+/*
+ * Copyright 1998-2019 Linux.org.ru
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+.code {
+  position: relative;
+}
+
+.code.spoiled {
+  height: 512px;
+  overflow-y: hidden;
+}
+
+.code .spoiler-open {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  background: linear-gradient(rgba(255,255,255,0.5), #fff);
+  display: table-cell;
+  text-align: center;
+  color: #000;
+}


### PR DESCRIPTION
Any code blocks that are higher than 512 pixels are automatically spoiled if JavaScript is enabled. Otherwise they are displayed completely, as before. The unspoil area is technically a link, so it is hinting-friendly ;-)

That's how it looks:
![2019-05-04-202405_1366x768_scrot](https://user-images.githubusercontent.com/2134486/57182884-ba916880-6ead-11e9-8760-f88c7d4a0546.png)
