### PR TITLE
Убран Клуб из доступных для переноса разделов форума

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,7 +10,7 @@ moscwich
 gentoo-root
 damnemall
 Andriy Shinkarchuk
-Valdos Nevermind Sine
+Vladimir Hodakov
 Victor Kukshiev 
 Alexey Kharlamov
 Tenno Seremel

--- a/src/main/webapp/WEB-INF/jsp/mtn.jsp
+++ b/src/main/webapp/WEB-INF/jsp/mtn.jsp
@@ -31,8 +31,10 @@
     <c:if test="${group.id == message.groupId}">
       <option value="${group.id}" selected="selected">${group.title}</option>
     </c:if>
-    <c:if test="${group.id != message.groupId}">
-      <option value="${group.id}">${group.title}</option>
+    <c:if test="${group.urlName != \"club\"}">
+      <c:if test="${group.id != message.groupId}">
+        <option value="${group.id}">${group.title}</option>
+      </c:if>
     </c:if>
   </c:forEach>
 </select>


### PR DESCRIPTION
Ибо нефиг. При этом для тем из Клуба селект не ломается: тему из Клуба вынести можно, а обратно — только через БД.