### PR TITLE
запуск highlight.js и после события load

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/head.jsp
+++ b/src/main/webapp/WEB-INF/jsp/head.jsp
@@ -55,5 +55,11 @@
     $script('/js/lor.js?MAVEN_BUILD_TIMESTAMP', 'lorjs');
   });
 
-  $script('/js/highlight.pack.js', 'hljs', function() { hljs.initHighlightingOnLoad(); });
+  $script('/js/highlight.pack.js', 'hljs');
+  $script.ready(['jquery', 'hljs'], function() {
+    $(function() {
+      hljs.initHighlighting();
+    });
+  });
+
 </script>


### PR DESCRIPTION
Подсветка кода работает ненадёжно. Иногда есть, иногда нет.
Проблема возникает из-за отложенной загрузки highlight.js. Она может произойти уже после того, как сработает событие 'load'. И тогда вызов initHighlightingOnLoad() не будет иметь никакого эффекта, потому что он сажает обработчик на 'load'.

Проще всего это пофиксить с помощью метода [ready](https://api.jquery.com/ready/) из jQuery.