### PR TITLE
Исправление конструктора MessageNotFoundException

### DIFF
--- a/src/main/java/ru/org/linux/site/MessageNotFoundException.java
+++ b/src/main/java/ru/org/linux/site/MessageNotFoundException.java
@@ -23,10 +23,11 @@ public class MessageNotFoundException extends ScriptErrorException {
   private final int id;
 
   public MessageNotFoundException(Topic topic, int commentId, String info) {
+    super(info);
     this.topic = topic;
-    id =commentId;
+    id = commentId;
   }
-  
+
   public MessageNotFoundException(int topicId, String info) {
     super(info);
     id = topicId;


### PR DESCRIPTION
В конструкторе MessageNotFoundException передавался аргумент info, который не уходил в родительский конструктор. В итоге сообщение об ошибке терялось.

Также был добавлен косметический пробел :)