### PR TITLE
Set a lighter color for blockquotes

### DIFF
--- a/src/main/webapp/sass/tango/_tango-dark.scss
+++ b/src/main/webapp/sass/tango/_tango-dark.scss
@@ -18,7 +18,7 @@ $text_color: #babdb6;
 $link_color: #729fcf;
 $site_title_color: #eeeeec;
 $header_color: #d3d7cf;
-$blockquote_color: #808080;
+$blockquote_color: #909090;
 
 $table_border_color: #555753;
 $table_header_background: $table_border_color;


### PR DESCRIPTION
По мотивам:

https://www.linux.org.ru/forum/linux-org-ru/16175149
https://www.linux.org.ru/forum/linux-org-ru/16174343

Лучше сделать цвет текста цитат немного светлее, так как на некоторых мониторах могут быть проблемы.