### PR TITLE
Shallow cloning on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,6 @@ before_script:
 before_install:
   - unset GEM_PATH
 install: mvn -B verify -DskipTests=true -Dmaven.javadoc.skip=true 
+
+git:
+  depth: 1


### PR DESCRIPTION
Travis CI provide a way to shallow clone a repository. This has the obvious benefit of speed, since you only need to download a small number of commits.