### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
   - createuser -U postgres -D -S -R linuxweb
   - createuser -U postgres -D -S -R jamwiki
   - createdb -U maxcom lor
-  - travis_wait psql -f sql/demo.db -U maxcom lor
+  - psql -f sql/demo.db -U maxcom lor
   - psql -c 'create extension hstore;' -U postgres lor
   - psql -c 'create extension fuzzystrmatch;' -U postgres lor
   - unset GEM_PATH
@@ -21,3 +21,6 @@ install: mvn -B verify -DskipTests=true -Dmaven.javadoc.skip=true
 
 git:
   depth: 1
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
