### PR TITLE
Fix spurious horizontal scroll on black theme

### DIFF
--- a/src/main/webapp/sass/black/style.scss
+++ b/src/main/webapp/sass/black/style.scss
@@ -232,6 +232,10 @@ blockquote {
   white-space: nowrap;
 }
 
+#related-topics-list {
+  overflow-x: hidden;  
+}
+
 #comments .userpic {
   margin-top: .75em;
 }


### PR DESCRIPTION
Before this fix the comments page on the black theme has a spurious horizontal scroll when it has a vertical scroll

The fix is identical to the older fix on white2 theme - https://github.com/maxcom/lorsource/pull/585/commits Tested via editing css via browser inspector