### PR TITLE
Fix for incorrect @username parsing issue

### DIFF
--- a/src/main/scala/ru/org/linux/util/markdown/LorUserExtension.scala
+++ b/src/main/scala/ru/org/linux/util/markdown/LorUserExtension.scala
@@ -85,8 +85,7 @@ class LorUserParserExtension(val inlineParser: InlineParser) extends InlineParse
 
     val possible = index == 0 || {
       val c = inlineParser.getInput.charAt(index - 1)
-
-      !Character.isUnicodeIdentifierPart(c) && c != '-' && c != '.'
+      c == ' '
     }
 
     if (possible) {


### PR DESCRIPTION

Idea is to trigger parsing only if previous character is 'space'.
Current implementation uses  !Character.isUnicodeIdentifierPart(c) 
which is too wide.