### PR TITLE
Поменял название на более удачное

### DIFF
--- a/src/main/webapp/WEB-INF/tags/comment.tag
+++ b/src/main/webapp/WEB-INF/tags/comment.tag
@@ -71,7 +71,7 @@
         <lor:sign user="${comment.author}" postdate="${comment.postdate}"/>
 
         <c:if test="${comment.author.id == topic.authorUserId and not comment.author.anonymous}">
-          <span class="user-tag">автор топика</span>
+          <span class="user-tag">автор темы</span>
         </c:if>
 
         <c:if test="${comment.remark!=null}">


### PR DESCRIPTION
По предложению одного из пользователей я решил заменить "автора топика" на "автора темы". По моему мнению, так лучше.