### PR TITLE
Удалил <link rel=""> из view-topic.jsp.

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/view-topic.jsp
+++ b/src/main/webapp/WEB-INF/jsp/view-topic.jsp
@@ -60,14 +60,6 @@
 
 <link rel="canonical" href="${configuration.secureUrlWithoutSlash}${message.getLinkPage(page)}">
 
-<c:if test="${prevMessage != null}">
-  <link rel="Previous" id="PrevLink" href="${fn:escapeXml(prevMessage.link)}" title="<l:title><l:mkTitle>${prevMessage.title}</l:mkTitle></l:title>">
-</c:if>
-
-<c:if test="${nextMessage != null}">
-  <link rel="Next" id="NextLink" href="${fn:escapeXml(nextMessage.link)}" title="<l:title><l:mkTitle>${nextMessage.title}</l:mkTitle></l:title>">
-</c:if>
-
 <script type="text/javascript">
   $script.ready('lorjs', function() { initNextPrevKeys(); });
   <c:if test="${not message.expired and template.sessionAuthorized}">


### PR DESCRIPTION
После https://github.com/maxcom/lorsource/pull/1068 пришла жалоба https://www.linux.org.ru/forum/linux-org-ru/17627235?cid=17642970
Предлагаю убрать обе ссылки, так как они конфликтуют с навигацией по страницам.

Плюс, эти ссылки были не совсем правильными: `Previous` вместо `prev`, `Next` вместо `next`. По этой причине Qutebrowser они не подхватывались.